### PR TITLE
Added preserveConstEnums in tsconfig so enum can be used at runtime

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "downlevelIteration": true,
     "outDir": "./lib",
     "rootDir": "./src",
-    "declaration": true
+    "declaration": true,
+    "preserveConstEnums": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
By default typescript inline the enum at compile time hence the enum cannot be used when transpiled in js. If you compile without this option, the spec.js in esm/ will be empty. With `preserveConstEnums` enabled it make it usable at runtime.